### PR TITLE
Add support for PHPCodeSniffer Composer Installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
             "email": "emiel.molenaar@gmail.com"
         }
     ],
+    "type": "phpcodesniffer-standard",
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "sirbrillig/phpcs-import-detection": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "emielmolenaar/phpcs-laravel",
-    "type": "library",
+    "type": "phpcodesniffer-standard",
     "description": "PHPCS libraries and configuration for Laravel",
     "keywords": [
         "phpcs",
@@ -14,7 +14,6 @@
             "email": "emiel.molenaar@gmail.com"
         }
     ],
-    "type": "phpcodesniffer-standard",
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "sirbrillig/phpcs-import-detection": "^1.1",


### PR DESCRIPTION
Set the package's composer.json `type` property to `phpcodesniffer-standard` for phpcs composer installers to automatically install the phpcs ruleset.

- https://github.com/Dealerdirect/phpcodesniffer-composer-installer#developing-coding-standards
- https://github.com/Dealerdirect/phpcodesniffer-composer-installer/wiki/Change-%60composer.json%60-%22type%22-to-%60phpcodesniffer-standard%60