### PR TITLE
Fix typo

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -74,7 +74,7 @@
     </rule>
     <rule ref="Generic">
         <exclude-pattern>*.php</exclude-pattern>
-        <exclude name="Generic.Strings.UnnecessaryStringConcat.Found)"/>
+        <exclude name="Generic.Strings.UnnecessaryStringConcat.Found"/>
     </rule>
 
     <file>app</file>


### PR DESCRIPTION
There's an unexpected character `)` on the rule.